### PR TITLE
Max-width snippet expanded to max-height instead

### DIFF
--- a/snippets/sass-indented.json
+++ b/snippets/sass-indented.json
@@ -510,7 +510,7 @@
 	},
 	"max-width": {
 		"prefix": "maxw",
-		"body": "max-height: $0"
+		"body": "max-width: $0"
 	},
 	"min-height": {
 		"prefix": "minh",


### PR DESCRIPTION
Max-width snippet was expanding to max-height. I made the change so it correctly expands to max-width.
