### PR TITLE
Move CHANGELOG from README to a standalone file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+| Version | Date | Changelog|
+| ------- | -------- | ------ |
+| 1.4.1 | 22.03.2017 | Add comment param highlighting. Fix adjoined id highlighting |
+| 1.4.0 | 21.03.2017 | Add comment param highlighting. Fix adjoined id highlighting |
+| 1.3.1 | 15.03.2017 | Remove association with `.scss` files |
+| 1.3.0 | 19.12.2016 | Revert to 1.1.0 functionality whilst performance issues are resolved |
+| 1.2.1 | 01.11.2016 | Add color preview to variable completion |
+| 1.2.0 | 28.10.2016 | Add global variable autocompletion |
+| 1.1.0 | 06.09.2016 | Rename sass-intended -> sass |
+| 1.0.0 | 02.09.2016 | Add property/value autocompletion |
+| 0.1.3 | 25.07.2016 | Publish v0.1.3 |
+| 0.1.0 | 21.12.2015 | Initial Release |

--- a/README.md
+++ b/README.md
@@ -31,14 +31,7 @@ Syntax highlighing - [https://github.com/P233/Syntax-highlighting-for-Sass](http
 Sass seal logo - [http://sass-lang.com/styleguide/brand](http://sass-lang.com/styleguide/brand)   
 
 ## Changelog
-1.4.0 - Add comment param highlighting. Fix adjoined id highlighting   
-1.3.1 - Remove association with `.scss` files   
-1.3.0 - Revert to 1.1.0 functionality whilst performance issues are resolved   
-1.2.1 - Add color preview to variable completion   
-1.2.0 - Add global variable autocompletion   
-1.1.0 - Rename sass-intended -> sass   
-1.0.0 - Add property/value autocompletion   
-0.1.0 - Initial Release   
+The full changelog is available here: [changelog](CHANGELOG.md). 
 
 ## License
 [MIT - https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Creating a CHANGELOG.md file will cause the `Changelog` tab within VSCode Extensions marketplace to be populated.